### PR TITLE
ファイルを読み直した場合にHeadHashが空になる問題を修正

### DIFF
--- a/in/ftail/ftail.go
+++ b/in/ftail/ftail.go
@@ -241,7 +241,7 @@ func (f *Ftail) getHeadHash(fname string, getLength int64) (hash string, length 
 	}
 	defer readFile.Close()
 	length, err = io.CopyN(f.headHash, readFile, getLength)
-	if err != io.EOF {
+	if err != nil && err != io.EOF {
 		return
 	}
 	hash = strconv.FormatUint(f.headHash.Sum64(), 16)


### PR DESCRIPTION
errがio.EOF以外の場合、errがnilの場合も含めてhashを空文字で返していたので、
errがnilの場合かio.EOFの場合にhashを返すように変更。
